### PR TITLE
Add support for IDv3 and operator v2 APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin
+obj
+.vs
+Properties

--- a/UID2.Client.nuspec
+++ b/UID2.Client.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UID2.Client</id>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
     <title>UID2 C# DSP Client Library</title>
     <authors>TTD</authors>
     <owners>TTD</owners>

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -32,6 +32,7 @@ namespace app
     {
         static string _baseUrl;
         static string _authKey;
+        static string _secretKey;
         static string _advertisingToken;
 
         static void StartExample(string name)
@@ -46,7 +47,7 @@ namespace app
         {
             StartExample("Basic keys refresh and decrypt token");
 
-            var client = UID2ClientFactory.Create(_baseUrl, _authKey);
+            var client = UID2ClientFactory.Create(_baseUrl, _authKey, _secretKey);
             var refreshResult = client.Refresh();
             if (!refreshResult.Success)
             {
@@ -58,13 +59,14 @@ namespace app
             Console.WriteLine($"DecryptedSuccess={result.Success} Status={result.Status}");
             Console.WriteLine($"UID={result.Uid}");
             Console.WriteLine($"EstablishedAt={result.Established}");
+            Console.WriteLine($"SiteId={result.SiteId}");
         }
 
         static void ExampleAutoRefresh()
         {
             StartExample("Automatic background keys refresh");
 
-            var client = UID2ClientFactory.Create(_baseUrl, _authKey);
+            var client = UID2ClientFactory.Create(_baseUrl, _authKey, _secretKey);
 
             var refreshThread = new Thread(() =>
             {
@@ -93,7 +95,7 @@ namespace app
         {
             StartExample("Encrypt and Decrypt Data");
 
-            var client = UID2ClientFactory.Create(_baseUrl, _authKey);
+            var client = UID2ClientFactory.Create(_baseUrl, _authKey, _secretKey);
             var refreshResult = client.Refresh();
             if (!refreshResult.Success)
             {
@@ -124,15 +126,16 @@ namespace app
 
         static int Main(string[] args)
         {
-            if (args.Length < 3)
+            if (args.Length < 4)
             {
-                Console.Error.WriteLine("Usage: test-client <base-url> <auth-key> <ad-token>");
+                Console.Error.WriteLine("Usage: test-client <base-url> <auth-key> <secret-key> <ad-token>");
                 return 1;
             }
 
             _baseUrl = args[0];
             _authKey = args[1];
-            _advertisingToken = args[2];
+            _secretKey = args[2];
+            _advertisingToken = args[3];
 
             ExampleBasicRefresh();
             ExampleAutoRefresh();

--- a/src/UID2.Client/DecryptionResponse.cs
+++ b/src/UID2.Client/DecryptionResponse.cs
@@ -34,17 +34,12 @@ namespace UID2.Client
         private readonly DateTime? _established;
         private readonly int? _siteId;
 
-        private DecryptionResponse(DecryptionStatus status, string uid, DateTime? established, int? siteId)
+        public DecryptionResponse(DecryptionStatus status, string uid, DateTime? established, int? siteId)
         {
             _status = status;
             _uid = uid;
             _established = established;
             _siteId = siteId;
-        }
-
-        public static DecryptionResponse MakeSuccess(string uid, DateTime established, int siteId)
-        {
-            return new DecryptionResponse(DecryptionStatus.Success, uid, established, siteId);
         }
 
         public static DecryptionResponse MakeError(DecryptionStatus status)

--- a/src/UID2.Client/DecryptionStatus.cs
+++ b/src/UID2.Client/DecryptionStatus.cs
@@ -33,5 +33,6 @@ namespace UID2.Client
         KeysNotSynced,
         VersionNotSupported,
         InvalidPayloadType,
+        InvalidIdentityScope,
     }
 }

--- a/src/UID2.Client/IUID2Client.cs
+++ b/src/UID2.Client/IUID2Client.cs
@@ -71,4 +71,12 @@ namespace UID2.Client
             return new UID2Client(endpoint, authKey, secretKey, IdentityScope.UID2);
         }
     }
+
+    public class EUIDClientFactory
+    {
+        public static IUID2Client Create(string endpoint, string authKey, string secretKey)
+        {
+            return new UID2Client(endpoint, authKey, secretKey, IdentityScope.EUID);
+        }
+    }
 }

--- a/src/UID2.Client/IUID2Client.cs
+++ b/src/UID2.Client/IUID2Client.cs
@@ -66,9 +66,9 @@ namespace UID2.Client
 
     public class UID2ClientFactory
     {
-        public static IUID2Client Create(string endpoint, string authKey)
+        public static IUID2Client Create(string endpoint, string authKey, string secretKey)
         {
-            return new UID2Client(endpoint, authKey);
+            return new UID2Client(endpoint, authKey, secretKey, IdentityScope.UID2);
         }
     }
 }

--- a/src/UID2.Client/IdentityScope.cs
+++ b/src/UID2.Client/IdentityScope.cs
@@ -23,9 +23,8 @@
 
 namespace UID2.Client
 {
-    internal enum PayloadType
+    internal enum IdentityScope
     {
-        ENCRYPTED_DATA = 128,
-        ENCRYPTED_DATA_V3 = 96,
+        UID2 = 0,
     }
 }

--- a/src/UID2.Client/IdentityScope.cs
+++ b/src/UID2.Client/IdentityScope.cs
@@ -26,5 +26,6 @@ namespace UID2.Client
     internal enum IdentityScope
     {
         UID2 = 0,
+        EUID = 1,
     }
 }

--- a/src/UID2.Client/IdentityType.cs
+++ b/src/UID2.Client/IdentityType.cs
@@ -26,5 +26,6 @@ namespace UID2.Client
     internal enum IdentityType
     {
         Email = 0,
+        Phone = 1,
     }
 }

--- a/src/UID2.Client/IdentityType.cs
+++ b/src/UID2.Client/IdentityType.cs
@@ -23,9 +23,8 @@
 
 namespace UID2.Client
 {
-    internal enum PayloadType
+    internal enum IdentityType
     {
-        ENCRYPTED_DATA = 128,
-        ENCRYPTED_DATA_V3 = 96,
+        Email = 0,
     }
 }

--- a/src/UID2.Client/KeyParser.cs
+++ b/src/UID2.Client/KeyParser.cs
@@ -36,8 +36,15 @@ namespace UID2.Client
         /// </summary>
         internal static KeyContainer Parse(string json)
         {
-            var response = JObject.Parse(json);
-            var body = response.Value<JArray>("body");
+            return Parse(JObject.Parse(json));
+        }
+
+        /// <summary>
+        /// Parse json data and load keys
+        /// </summary>
+        internal static KeyContainer Parse(JObject json)
+        {
+            var body = json.Value<JArray>("body");
 
             var keys = body.Select(i => (JObject)i).Select(item => new Key(
                     item.Value<long>("id"),

--- a/src/UID2.Client/UID2.Client.csproj
+++ b/src/UID2.Client/UID2.Client.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/UID2.Client/UID2Client.cs
+++ b/src/UID2.Client/UID2Client.cs
@@ -21,7 +21,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Net;
@@ -147,8 +146,8 @@ namespace UID2.Client
                     using (var reader = new StreamReader(responseStream))
                     {
                         var responseBody = await reader.ReadToEndAsync().ConfigureAwait(false);
-                        var json = V2Helper.ParseResponse(responseBody, _secretKey, nonce);
-                        Volatile.Write(ref _container, KeyParser.Parse(json));
+                        var responseBytes = V2Helper.ParseResponse(responseBody, _secretKey, nonce);
+                        Volatile.Write(ref _container, KeyParser.Parse(Encoding.UTF8.GetString(responseBytes)));
                     }
                     return RefreshResponse.MakeSuccess();
                 }

--- a/src/UID2.Client/UID2Client.cs
+++ b/src/UID2.Client/UID2Client.cs
@@ -21,6 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Net;
@@ -28,27 +29,30 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using UID2.Client.Utils;
 
 namespace UID2.Client
 {
     internal class UID2Client : IUID2Client
     {
-        public static readonly HttpMethod RefreshHttpMethod = HttpMethod.Get;
+        public static readonly HttpMethod RefreshHttpMethod = HttpMethod.Post;
 
         private readonly string _endpoint;
         private readonly string _authKey;
+        private readonly byte[] _secretKey;
+        private readonly IdentityScope _identityScope;
 
         private readonly HttpClient _client;
 
         private KeyContainer _container;
 
 
-        public UID2Client(string endpoint, string authKey)
+        public UID2Client(string endpoint, string authKey, string secretKey, IdentityScope identityScope)
         {
             _client = new HttpClient();
             _endpoint = endpoint;
             _authKey = authKey;
+            _secretKey = Convert.FromBase64String(secretKey);
+            _identityScope = identityScope;
         }
         
         public DecryptionResponse Decrypt(string token, DateTime now)
@@ -66,7 +70,7 @@ namespace UID2.Client
 
             try
             {
-                return UID2Encryption.Decrypt(Convert.FromBase64String(token), container, now);
+                return UID2Encryption.Decrypt(Convert.FromBase64String(token), container, now, _identityScope);
             }
             catch (Exception)
             {
@@ -76,7 +80,7 @@ namespace UID2.Client
 
         public EncryptionDataResponse EncryptData(EncryptionDataRequest request)
         {
-            return UID2Encryption.EncryptData(request, Volatile.Read(ref _container));
+            return UID2Encryption.EncryptData(request, Volatile.Read(ref _container), _identityScope);
         }
 
         public DecryptionDataResponse DecryptData(String encryptedData)
@@ -94,7 +98,7 @@ namespace UID2.Client
 
             try
             {
-                return UID2Encryption.DecryptData(Convert.FromBase64String(encryptedData), container);
+                return UID2Encryption.DecryptData(Convert.FromBase64String(encryptedData), container, _identityScope);
             }
             catch (Exception)
             {
@@ -127,11 +131,14 @@ namespace UID2.Client
 
         private async Task<RefreshResponse> RefreshInternal(CancellationToken token)
         {
-            var request = new HttpRequestMessage(RefreshHttpMethod, _endpoint + "/v1/key/latest");
+            var request = new HttpRequestMessage(RefreshHttpMethod, _endpoint + "/v2/key/latest");
             request.Headers.Add("Authorization", $"Bearer {_authKey}");
             HttpStatusCode? statusCode = null;
             try
             {
+                var (body, nonce) = V2Helper.MakeEnvelope(_secretKey, DateTime.UtcNow);
+                request.Content = new StringContent(body, Encoding.ASCII);
+
                 using (var response = await _client.SendAsync(request, token).ConfigureAwait(false))
                 {
                     statusCode = response.StatusCode;
@@ -139,7 +146,8 @@ namespace UID2.Client
                     var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     using (var reader = new StreamReader(responseStream))
                     {
-                        var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        var responseBody = await reader.ReadToEndAsync().ConfigureAwait(false);
+                        var json = V2Helper.ParseResponse(responseBody, _secretKey, nonce);
                         Volatile.Write(ref _container, KeyParser.Parse(json));
                     }
                     return RefreshResponse.MakeSuccess();

--- a/src/UID2.Client/UID2Encryption.cs
+++ b/src/UID2.Client/UID2Encryption.cs
@@ -39,13 +39,13 @@ namespace UID2.Client
 
         internal static DecryptionResponse Decrypt(byte[] encryptedId, IKeyContainer keys, DateTime now, IdentityScope identityScope)
         {
-            if (encryptedId[1] == 112 && encryptedId[0] != 2)
-            {
-                return DecryptV3(encryptedId, keys, now, identityScope);
-            }
-            else if (encryptedId[0] == 2)
+            if (encryptedId[0] == 2)
             {
                 return DecryptV2(encryptedId, keys, now);
+            }
+            else if (encryptedId[1] == 112)
+            {
+                return DecryptV3(encryptedId, keys, now, identityScope);
             }
 
             return DecryptionResponse.MakeError(DecryptionStatus.VersionNotSupported);

--- a/src/UID2.Client/UID2Encryption.cs
+++ b/src/UID2.Client/UID2Encryption.cs
@@ -21,6 +21,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -31,15 +34,29 @@ namespace UID2.Client
 {
     internal static class UID2Encryption
     {
-        internal static DecryptionResponse Decrypt(byte[] encryptedId, IKeyContainer keys, DateTime now)
+        public const int GCM_AUTHTAG_LENGTH = 16;
+        public const int GCM_IV_LENGTH = 12;
+
+        internal static DecryptionResponse Decrypt(byte[] encryptedId, IKeyContainer keys, DateTime now, IdentityScope identityScope)
+        {
+            if (encryptedId[1] == 112 && encryptedId[0] != 2)
+            {
+                return DecryptV3(encryptedId, keys, now, identityScope);
+            }
+            else if (encryptedId[0] == 2)
+            {
+                return DecryptV2(encryptedId, keys, now);
+            }
+
+            return DecryptionResponse.MakeError(DecryptionStatus.VersionNotSupported);
+        }
+
+        private static DecryptionResponse DecryptV2(byte[] encryptedId, IKeyContainer keys, DateTime now)
         {
             var reader = new BigEndianByteReader(new MemoryStream(encryptedId));
 
-            var version = (int)reader.ReadByte();
-            if (version != 2)
-            {
-                return DecryptionResponse.MakeError(DecryptionStatus.VersionNotSupported);
-            }
+            // version
+            reader.ReadByte();
 
             var masterKeyId = reader.ReadInt32();
 
@@ -54,11 +71,6 @@ namespace UID2.Client
             var masterPayloadReader = new BigEndianByteReader(new MemoryStream(masterDecrypted));
 
             long expiresMilliseconds = masterPayloadReader.ReadInt64();
-            var expiry = DateTimeUtils.FromEpochMilliseconds(expiresMilliseconds);
-            if (expiry < now)
-            {
-                return DecryptionResponse.MakeError(DecryptionStatus.ExpiredToken);
-            }
 
             var siteKeyId = masterPayloadReader.ReadInt32();
 
@@ -85,10 +97,84 @@ namespace UID2.Client
 
             var established = DateTimeUtils.FromEpochMilliseconds(establishedMilliseconds);
 
-            return DecryptionResponse.MakeSuccess(idString, established, siteId);
+            var expiry = DateTimeUtils.FromEpochMilliseconds(expiresMilliseconds);
+            if (expiry < now)
+            {
+                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId);
+            }
+            else
+            {
+                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId);
+            }
         }
 
-        internal static EncryptionDataResponse EncryptData(EncryptionDataRequest request, IKeyContainer keys)
+        private static DecryptionResponse DecryptV3(byte[] encryptedId, IKeyContainer keys, DateTime now, IdentityScope identityScope)
+        {
+            var reader = new BigEndianByteReader(new MemoryStream(encryptedId));
+
+            var prefix = reader.ReadByte();
+            if (DecodeIdentityScopeV3(prefix) != identityScope)
+            {
+                return DecryptionResponse.MakeError(DecryptionStatus.InvalidIdentityScope);
+            }
+
+            // version
+            reader.ReadByte();
+
+            var masterKeyId = reader.ReadInt32();
+
+            Key masterKey = null;
+            if (!keys.TryGetKey(masterKeyId, out masterKey))
+            {
+                return DecryptionResponse.MakeError(DecryptionStatus.NotAuthorizedForKey);
+            }
+
+            var masterDecrypted = DecryptGCM(new ByteArraySlice(encryptedId, 6, encryptedId.Length - 6), masterKey.Secret);
+            var masterPayloadReader = new BigEndianByteReader(new MemoryStream(masterDecrypted));
+
+            long expiresMilliseconds = masterPayloadReader.ReadInt64();
+            long createdMilliseconds = masterPayloadReader.ReadInt64();
+
+            int operatorSiteId = masterPayloadReader.ReadInt32();
+            byte operatorType = masterPayloadReader.ReadByte();
+            int operatorVersion = masterPayloadReader.ReadInt32();
+            int operatorKeyId = masterPayloadReader.ReadInt32();
+
+            var siteKeyId = masterPayloadReader.ReadInt32();
+
+            Key siteKey = null;
+            if (!keys.TryGetKey(siteKeyId, out siteKey))
+            {
+                return DecryptionResponse.MakeError(DecryptionStatus.NotAuthorizedForKey);
+            }
+
+            var sitePayload = DecryptGCM(new ByteArraySlice(masterDecrypted, 33, masterDecrypted.Length - 33), siteKey.Secret);
+            var sitePayloadReader = new BigEndianByteReader(new MemoryStream(sitePayload));
+
+            var siteId = sitePayloadReader.ReadInt32();
+            var publisherId = sitePayloadReader.ReadInt64();
+            var publisherKeyId = sitePayloadReader.ReadInt32();
+
+            var privacyBits = sitePayloadReader.ReadInt32();
+            var establishedMilliseconds = sitePayloadReader.ReadInt64();
+            var refreshedMilliseconds = sitePayloadReader.ReadInt64();
+            var id = sitePayloadReader.ReadBytes(sitePayload.Length - 36);
+
+            var established = DateTimeUtils.FromEpochMilliseconds(establishedMilliseconds);
+            var idString = Convert.ToBase64String(id);
+
+            var expiry = DateTimeUtils.FromEpochMilliseconds(expiresMilliseconds);
+            if (expiry < now)
+            {
+                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId);
+            }
+            else
+            {
+                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId);
+            }
+        }
+
+        internal static EncryptionDataResponse EncryptData(EncryptionDataRequest request, IKeyContainer keys, IdentityScope identityScope)
         {
             if (request.Data == null)
             {
@@ -120,7 +206,7 @@ namespace UID2.Client
                 {
                     try
                     {
-                        DecryptionResponse decryptedToken = Decrypt(Convert.FromBase64String(request.AdvertisingToken), keys, now);
+                        DecryptionResponse decryptedToken = Decrypt(Convert.FromBase64String(request.AdvertisingToken), keys, now, identityScope);
                         if (!decryptedToken.Success)
                         {
                             return EncryptionDataResponse.MakeError(EncryptionStatus.TokenDecryptFailure);
@@ -151,19 +237,24 @@ namespace UID2.Client
             byte[] iv = request.InitializationVector;
             if (iv == null)
             {
-                iv = GenerateIv();
+                iv = GenerateIV(GCM_IV_LENGTH);
             }
 
             try
             {
-                byte[] encryptedData = Encrypt(request.Data, iv, key.Secret);
-                var ms = new MemoryStream(encryptedData.Length + 18);
+                var payloadStream = new MemoryStream(request.Data.Length + 12);
+                var payloadWriter = new BigEndianByteWriter(payloadStream);
+                payloadWriter.Write(DateTimeUtils.DateTimeToEpochMilliseconds(now));
+                payloadWriter.Write(siteId);
+                payloadWriter.Write(request.Data);
+
+                byte[] encryptedData = EncryptGCM(payloadStream.ToArray(), iv, key.Secret);
+                var ms = new MemoryStream(encryptedData.Length + GCM_IV_LENGTH + GCM_AUTHTAG_LENGTH + 6);
                 var writer = new BigEndianByteWriter(ms);
-                writer.Write((byte)PayloadType.ENCRYPTED_DATA);
-                writer.Write((byte)1); // version
-                writer.Write(DateTimeUtils.DateTimeToEpochMilliseconds(now));
-                writer.Write(siteId);
+                writer.Write((byte)((int)PayloadType.ENCRYPTED_DATA_V3 | ((int)identityScope << 4) | 0xB));
+                writer.Write((byte)112); // version
                 writer.Write((int)key.Id);
+                writer.Write(iv);
                 writer.Write(encryptedData);
                 return EncryptionDataResponse.MakeSuccess(Convert.ToBase64String(ms.ToArray()));
             }
@@ -173,14 +264,26 @@ namespace UID2.Client
             }
         }
 
-        internal static DecryptionDataResponse DecryptData(byte[] encryptedBytes, IKeyContainer keys)
+        internal static DecryptionDataResponse DecryptData(byte[] encryptedBytes, IKeyContainer keys, IdentityScope identityScope)
+        {
+            if ((encryptedBytes[0] & 224) == (int)PayloadType.ENCRYPTED_DATA_V3)
+            {
+                return DecryptDataV3(encryptedBytes, keys, identityScope);
+            }
+            else
+            {
+                return DecryptDataV2(encryptedBytes, keys);
+            }
+        }
+
+        internal static DecryptionDataResponse DecryptDataV2(byte[] encryptedBytes, IKeyContainer keys)
         {
             var reader = new BigEndianByteReader(new MemoryStream(encryptedBytes));
             if (reader.ReadByte() != (byte)PayloadType.ENCRYPTED_DATA)
             {
                 return DecryptionDataResponse.MakeError(DecryptionStatus.InvalidPayloadType);
             }
-            else if (reader.ReadByte() != 1)
+            if (reader.ReadByte() != 1)
             {
                 return DecryptionDataResponse.MakeError(DecryptionStatus.VersionNotSupported);
             }
@@ -196,6 +299,37 @@ namespace UID2.Client
 
             byte[] iv = reader.ReadBytes(16);
             byte[] decryptedData = Decrypt(new ByteArraySlice(encryptedBytes, 34, encryptedBytes.Length - 34), iv, key.Secret);
+
+            return DecryptionDataResponse.MakeSuccess(decryptedData, encryptedAt);
+        }
+
+        internal static DecryptionDataResponse DecryptDataV3(byte[] encryptedBytes, IKeyContainer keys, IdentityScope identityScope)
+        {
+            var reader = new BigEndianByteReader(new MemoryStream(encryptedBytes));
+            var payloadScope = DecodeIdentityScopeV3(reader.ReadByte());
+            if (payloadScope != identityScope)
+            {
+                return DecryptionDataResponse.MakeError(DecryptionStatus.InvalidIdentityScope);
+            }
+            if (reader.ReadByte() != 112)
+            {
+                return DecryptionDataResponse.MakeError(DecryptionStatus.VersionNotSupported);
+            }
+
+            long keyId = reader.ReadInt32();
+            if (!keys.TryGetKey(keyId, out var key))
+            {
+                return DecryptionDataResponse.MakeError(DecryptionStatus.NotAuthorizedForKey);
+            }
+
+            var decryptedBytes = DecryptGCM(new ByteArraySlice(encryptedBytes, 6, encryptedBytes.Length - 6), key.Secret);
+            var decryptedReader = new BigEndianByteReader(new MemoryStream(decryptedBytes));
+
+            DateTime encryptedAt = DateTimeUtils.FromEpochMilliseconds(decryptedReader.ReadInt64());
+            int siteId = decryptedReader.ReadInt32();
+
+            var decryptedData = new byte[decryptedBytes.Length - 12];
+            Array.Copy(decryptedBytes, 12, decryptedData, 0, decryptedData.Length);
 
             return DecryptionDataResponse.MakeSuccess(decryptedData, encryptedAt);
         }
@@ -226,11 +360,46 @@ namespace UID2.Client
             }
         }
 
-        private static byte[] GenerateIv()
+        internal static (byte[], byte[]) EncryptGCM(byte[] data, byte[] secret)
         {
-            byte[] iv = new byte[16];
+            var iv = GenerateIV(GCM_IV_LENGTH);
+            return (iv, EncryptGCM(data, iv, secret));
+        }
+
+        internal static byte[] EncryptGCM(byte[] data, byte[] iv, byte[] secret)
+        {
+            var cipher = new GcmBlockCipher(new AesEngine());
+            var parameters = new AeadParameters(new KeyParameter(secret), GCM_AUTHTAG_LENGTH * 8, iv, null);
+            cipher.Init(true, parameters);
+            var cipherText = new byte[cipher.GetOutputSize(data.Length)];
+            var len = cipher.ProcessBytes(data, 0, data.Length, cipherText, 0);
+            cipher.DoFinal(cipherText, len);
+            return cipherText;
+        }
+
+        internal static byte[] DecryptGCM(ByteArraySlice cipherText, byte[] secret)
+        {
+            var iv = new byte[GCM_IV_LENGTH];
+            Array.Copy(cipherText.Buffer, cipherText.Offset, iv, 0, iv.Length);
+            var cipher = new GcmBlockCipher(new AesEngine());
+            var parameters = new AeadParameters(new KeyParameter(secret), GCM_AUTHTAG_LENGTH * 8, iv, null);
+            cipher.Init(false, parameters);
+            var plainText = new byte[cipher.GetOutputSize(cipherText.Count - GCM_IV_LENGTH)];
+            var len = cipher.ProcessBytes(cipherText.Buffer, cipherText.Offset + GCM_IV_LENGTH, cipherText.Count - GCM_IV_LENGTH, plainText, 0);
+            cipher.DoFinal(plainText, len);
+            return plainText;
+        }
+
+        private static byte[] GenerateIV(int len = 16)
+        {
+            byte[] iv = new byte[len];
             RNGCryptoServiceProvider.Create().GetBytes(iv);
             return iv;
+        }
+
+        private static IdentityScope DecodeIdentityScopeV3(byte value)
+        {
+            return (IdentityScope)((value >> 4) & 1);
         }
     }
 }

--- a/src/UID2.Client/V2Helper.cs
+++ b/src/UID2.Client/V2Helper.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Text;
+using UID2.Client.Utils;
+
+namespace UID2.Client
+{
+    internal static class V2Helper
+    {
+        private static (byte[], byte[]) MakePayload(DateTime now)
+        {
+            var ms = new MemoryStream(16);
+            var writer = new BigEndianByteWriter(ms);
+            writer.Write(DateTimeUtils.DateTimeToEpochMilliseconds(now));
+            var nonce = new byte[8];
+            ThreadSafeRandom.PerThread.NextBytes(nonce);
+            ms.Write(nonce, 0, nonce.Length);
+            return (ms.ToArray(), nonce);
+        }
+
+        internal static (string, byte[]) MakeEnvelope(byte[] secret, DateTime now)
+        {
+            var (payload, nonce) = MakePayload(now);
+            var (iv, encrypted) = UID2Encryption.EncryptGCM(payload, secret);
+            var envelope = new byte[1 + iv.Length + encrypted.Length];
+            envelope[0] = 1;
+            Array.Copy(iv, 0, envelope, 1, iv.Length);
+            Array.Copy(encrypted, 0, envelope, 1 + iv.Length, encrypted.Length);
+            var encodedEnvelope = Convert.ToBase64String(envelope);
+            return (encodedEnvelope, nonce);
+        }
+
+        internal static JObject ParseResponse(string envelope, byte[] secret, byte[] nonce)
+        {
+            var envelopeBytes = Convert.FromBase64String(envelope);
+            var payload = UID2Encryption.DecryptGCM(new ByteArraySlice(envelopeBytes, 0, envelopeBytes.Length), secret);
+            var response = JObject.Parse(Encoding.UTF8.GetString(payload));
+            var nonceString = Convert.ToBase64String(nonce);
+            if (response.Value<string>("nonce") != nonceString)
+            {
+                throw new InvalidDataException("nonce mismatch");
+            }
+
+            return response;
+        }
+    }
+}

--- a/test/UID2.Client.Test.Utils/UID2TokenGenerator.cs
+++ b/test/UID2.Client.Test.Utils/UID2TokenGenerator.cs
@@ -21,6 +21,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -42,13 +45,16 @@ namespace UID2.Client.Test.Utils
 
             public Params() { }
             public Params WithTokenExpiry(DateTime expiry) { TokenExpiry = expiry; return this; }
+
+            public int IdentityScope = (int)UID2.Client.IdentityScope.UID2;
+            public int IdentityType = (int)UID2.Client.IdentityType.Email;
         }
 
         public static Params DefaultParams => new Params();
 
-        public static string GenerateUID2Token(string uid, Key masterKey, int siteId, Key siteKey)
+        public static string GenerateUID2TokenV2(string uid, Key masterKey, int siteId, Key siteKey)
         {
-            return GenerateUID2Token(uid, masterKey, siteId, siteKey, DefaultParams);
+            return GenerateUID2TokenV2(uid, masterKey, siteId, siteKey, DefaultParams);
         }
         
         /// <summary>
@@ -60,7 +66,7 @@ namespace UID2.Client.Test.Utils
         /// <param name="siteKey">site-specific key to encrypt the UID with first before encrypting again with master key</param>
         /// <param name="encryptParams"></param>
         /// <returns>the encrypted UID in the form of UID2 Token</returns>
-        public static string GenerateUID2Token(string uid, Key masterKey, int siteId, Key siteKey, Params encryptParams)
+        public static string GenerateUID2TokenV2(string uid, Key masterKey, int siteId, Key siteKey, Params encryptParams)
         {
             var uidBytes = Encoding.UTF8.GetBytes(uid);
             var identityStream = new MemoryStream();
@@ -93,6 +99,85 @@ namespace UID2.Client.Test.Utils
             return Convert.ToBase64String(rootStream.ToArray());
         }
 
+        public static string GenerateUID2TokenV3(string uid, Key masterKey, int siteId, Key siteKey)
+        {
+            return GenerateUID2TokenV3(uid, masterKey, siteId, siteKey, DefaultParams);
+        }
+
+        /// <summary>
+        ///  The data can be decrypted with UID2.Client.IUID2Client.Decrypt method
+        /// </summary>
+        /// <param name="uid">UID to be encrypted to a UID2 Token</param>
+        /// <param name="masterKey">The mandatory key that is not site-specific and would encrypt UID into a UID2 Token</param>
+        /// <param name="siteId">The unique identifier of the publisher</param>
+        /// <param name="siteKey">site-specific key to encrypt the UID with first before encrypting again with master key</param>
+        /// <param name="encryptParams"></param>
+        /// <returns>the encrypted UID in the form of UID2 Token</returns>
+        public static string GenerateUID2TokenV3(string uid, Key masterKey, int siteId, Key siteKey, Params encryptParams)
+        {
+            var sitePayload = new MemoryStream();
+            var sitePayloadWriter = new BigEndianByteWriter(sitePayload);
+
+            // publisher data
+            sitePayloadWriter.Write(siteId);
+            sitePayloadWriter.Write(0L); // publisher id
+            sitePayloadWriter.Write(0); // client key id
+
+            // user identity data
+            sitePayloadWriter.Write(0); // privacy bits
+            sitePayloadWriter.Write(DateTimeUtils.DateTimeToEpochMilliseconds(DateTime.UtcNow.AddHours(-1))); // established
+            sitePayloadWriter.Write(DateTimeUtils.DateTimeToEpochMilliseconds(DateTime.UtcNow)); // last refreshed
+            sitePayloadWriter.Write(Convert.FromBase64String(uid));
+
+            var masterPayload = new MemoryStream();
+            var masterPayloadWriter = new BigEndianByteWriter(masterPayload);
+            masterPayloadWriter.Write(DateTimeUtils.DateTimeToEpochMilliseconds(encryptParams.TokenExpiry));
+            masterPayloadWriter.Write(DateTimeUtils.DateTimeToEpochMilliseconds(DateTime.UtcNow)); // token created
+
+            // operator identity data
+            masterPayloadWriter.Write(0); // site id
+            masterPayloadWriter.Write((byte)1); // operator type
+            masterPayloadWriter.Write(0); // operator version
+            masterPayloadWriter.Write(0); // operator key id
+            masterPayloadWriter.Write((int)siteKey.Id);
+
+            byte[] siteIv = new byte[12];
+            ThreadSafeRandom.PerThread.NextBytes(siteIv);
+            masterPayloadWriter.Write(siteIv);
+            masterPayloadWriter.Write(EncryptGCM(sitePayload.ToArray(), siteIv, siteKey.Secret));
+
+            var rootStream = new MemoryStream();
+            var rootStreamWriter = new BigEndianByteWriter(rootStream);
+            rootStreamWriter.Write((byte)((encryptParams.IdentityScope << 4) | (encryptParams.IdentityType << 2)));
+            rootStreamWriter.Write((byte)112);
+            rootStreamWriter.Write((int)masterKey.Id);
+
+            byte[] masterIv = new byte[12];
+            ThreadSafeRandom.PerThread.NextBytes(masterIv);
+            rootStreamWriter.Write(masterIv);
+            rootStreamWriter.Write(EncryptGCM(masterPayload.ToArray(), masterIv, masterKey.Secret));
+
+            return Convert.ToBase64String(rootStream.ToArray());
+        }
+
+        public static string EncryptDataV2(byte[] data, Key key, int siteId, DateTime now)
+        {
+            var iv = new byte[16];
+            ThreadSafeRandom.PerThread.NextBytes(iv);
+            byte[] encryptedData = Encrypt(data, iv, key.Secret);
+            
+            var ms = new MemoryStream(encryptedData.Length);
+            var writer = new BigEndianByteWriter(ms);
+            writer.Write((byte)PayloadType.ENCRYPTED_DATA);
+            writer.Write((byte)1); // version
+            writer.Write(DateTimeUtils.DateTimeToEpochMilliseconds(now));
+            writer.Write(siteId);
+            writer.Write((int)key.Id);
+            writer.Write(encryptedData);
+
+            return Convert.ToBase64String(ms.ToArray());
+        }
+
         private static byte[] Encrypt(byte[] data, byte[] iv, byte[] secret)
         {
             using (var r = new RijndaelManaged() { Key = secret, IV = iv, Mode = CipherMode.CBC })
@@ -105,6 +190,18 @@ namespace UID2.Client.Test.Utils
 
                 return ms.ToArray();
             }
+        }
+
+        private static byte[] EncryptGCM(byte[] data, byte[] iv, byte[] secret)
+        {
+            const int GCM_TAG_LEN = 16;
+            var cipher = new GcmBlockCipher(new AesEngine());
+            var parameters = new AeadParameters(new KeyParameter(secret), GCM_TAG_LEN * 8, iv, null);
+            cipher.Init(true, parameters);
+            var cipherText = new byte[cipher.GetOutputSize(data.Length)];
+            var len = cipher.ProcessBytes(data, 0, data.Length, cipherText, 0);
+            cipher.DoFinal(cipherText, len);
+            return cipherText;
         }
     }
 }

--- a/test/UID2.Client.Test/EncryptionTestsV2.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV2.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) 2021 The Trade Desk, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Linq;
+using UID2.Client.Test.Utils;
+using UID2.Client.Utils;
+using Xunit;
+
+namespace UID2.Client.Test
+{
+    public class EncryptionTestsV2
+    {
+        private static readonly long MASTER_KEY_ID = 164;
+        private static readonly long SITE_KEY_ID = 165;
+        private static readonly int SITE_ID = 9000;
+        private static readonly byte[] MASTER_SECRET = { 139, 37, 241, 173, 18, 92, 36, 232, 165, 168, 23, 18, 38, 195, 123, 92, 160, 136, 185, 40, 91, 173, 165, 221, 168, 16, 169, 164, 38, 139, 8, 155 };
+        private static readonly byte[] SITE_SECRET = { 32, 251, 7, 194, 132, 154, 250, 86, 202, 116, 104, 29, 131, 192, 139, 215, 48, 164, 11, 65, 226, 110, 167, 14, 108, 51, 254, 125, 65, 24, 23, 133 };
+        private static readonly DateTime NOW = DateTime.UtcNow;
+        private static readonly Key MASTER_KEY = new Key(MASTER_KEY_ID, -1, NOW.AddDays(-1), NOW, NOW.AddDays(1), MASTER_SECRET);
+        private static readonly Key SITE_KEY = new Key(SITE_KEY_ID, SITE_ID, NOW.AddDays(-10), NOW.AddDays(-1), NOW.AddDays(1), SITE_SECRET);
+        private static readonly string EXAMPLE_UID = "ywsvDNINiZOVSsfkHpLpSJzXzhr6Jx9Z/4Q0+lsEUvM=";
+        private static readonly string CLIENT_SECRET = "ioG3wKxAokmp+rERx6A4kM/13qhyolUXIu14WN16Spo=";
+
+        [Fact]
+        public void SmokeTest()
+        {
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            var refreshResult = client.RefreshJson(KeySetToJson(MASTER_KEY, SITE_KEY));
+            Assert.True(refreshResult.Success);
+            String advertisingToken = UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+            var res = client.Decrypt(advertisingToken, NOW);
+            Assert.True(res.Success);
+            Assert.Equal(EXAMPLE_UID, res.Uid);
+        }
+
+        [Fact]
+        public void EmptyKeyContainer()
+        {
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            var advertisingToken = UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+            var res = client.Decrypt(advertisingToken, NOW);
+            Assert.False(res.Success);
+            Assert.Equal(DecryptionStatus.NotInitialized, res.Status);
+        }
+
+        [Fact]
+        public void ExpiredKeyContainer()
+        {
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            var advertisingToken = UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+
+            Key masterKeyExpired = new Key(MASTER_KEY_ID, -1, NOW, NOW.AddHours(-2), NOW.AddHours(-1), MASTER_SECRET);
+            Key siteKeyExpired = new Key(SITE_KEY_ID, SITE_ID, NOW, NOW.AddHours(-2), NOW.AddHours(-1), SITE_SECRET);
+            client.RefreshJson(KeySetToJson(masterKeyExpired, siteKeyExpired));
+
+            var res = client.Decrypt(advertisingToken, NOW);
+            Assert.False(res.Success);
+            Assert.Equal(DecryptionStatus.KeysNotSynced, res.Status);
+        }
+
+        [Fact]
+        public void NotAuthorizedForKey()
+        {
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            var advertisingToken = UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY);
+
+            Key anotherMasterKey = new Key(MASTER_KEY_ID + SITE_KEY_ID + 1, -1, NOW, NOW, NOW.AddHours(1), MASTER_SECRET);
+            Key anotherSiteKey = new Key(MASTER_KEY_ID + SITE_KEY_ID + 2, SITE_ID, NOW, NOW, NOW.AddHours(1), SITE_SECRET);
+            client.RefreshJson(KeySetToJson(anotherMasterKey, anotherSiteKey));
+
+            var res = client.Decrypt(advertisingToken, NOW);
+            Assert.Equal(DecryptionStatus.NotAuthorizedForKey, res.Status);
+        }
+
+        [Fact]
+        public void InvalidPayload()
+        {
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            byte[] payload = Convert.FromBase64String(UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY));
+            var advertisingToken = Convert.ToBase64String(payload.SkipLast(1).ToArray());
+
+            client.RefreshJson(KeySetToJson(MASTER_KEY, SITE_KEY));
+
+            var res = client.Decrypt(advertisingToken, NOW);
+            Assert.Equal(DecryptionStatus.InvalidPayload, res.Status);
+        }
+
+        [Fact]
+        public void TokenExpiryAndCustomNow()
+        {
+            var expiry = NOW.AddDays(-60);
+            var encryptParams = UID2TokenGenerator.DefaultParams.WithTokenExpiry(expiry);
+
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(MASTER_KEY, SITE_KEY));
+            var advertisingToken = UID2TokenGenerator.GenerateUID2TokenV2(EXAMPLE_UID, MASTER_KEY, SITE_ID, SITE_KEY, encryptParams);
+
+            var res = client.Decrypt(advertisingToken, expiry.AddSeconds(1));
+            Assert.Equal(DecryptionStatus.ExpiredToken, res.Status);
+
+            res = client.Decrypt(advertisingToken, expiry.AddSeconds(-1));
+            Assert.Equal(EXAMPLE_UID, res.Uid);
+        }
+
+        [Fact]
+        public void DecryptData()
+        {
+            byte[] data = { 1, 2, 3, 4, 5, 6 };
+
+            var now = DateTimeUtils.FromEpochMilliseconds(DateTimeUtils.DateTimeToEpochMilliseconds(DateTime.UtcNow));
+            var encrypted = UID2TokenGenerator.EncryptDataV2(data, SITE_KEY, 12345, now);
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(SITE_KEY));
+            var decrypted = client.DecryptData(encrypted);
+            Assert.Equal(DecryptionStatus.Success, decrypted.Status);
+            Assert.Equal(data, decrypted.DecryptedData);
+            Assert.Equal(now, decrypted.EncryptedAt);
+        }
+
+        [Fact]
+        public void DecryptDataBadPayloadType()
+        {
+            byte[] data = { 1, 2, 3, 4, 5, 6 };
+            var encrypted = UID2TokenGenerator.EncryptDataV2(data, SITE_KEY, 12345, DateTime.UtcNow);
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(SITE_KEY));
+            byte[] encryptedBytes = Convert.FromBase64String(encrypted);
+            encryptedBytes[0] = 0;
+            var decrypted = client.DecryptData(Convert.ToBase64String(encryptedBytes));
+            Assert.Equal(DecryptionStatus.InvalidPayloadType, decrypted.Status);
+        }
+
+        [Fact]
+        public void DecryptDataBadVersion()
+        {
+            byte[] data = { 1, 2, 3, 4, 5, 6 };
+            var encrypted = UID2TokenGenerator.EncryptDataV2(data, SITE_KEY, 12345, DateTime.UtcNow);
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(SITE_KEY));
+            byte[] encryptedBytes = Convert.FromBase64String(encrypted);
+            encryptedBytes[1] = 0;
+            var decrypted = client.DecryptData(Convert.ToBase64String(encryptedBytes));
+            Assert.Equal(DecryptionStatus.VersionNotSupported, decrypted.Status);
+        }
+
+        [Fact]
+        public void DecryptDataBadPayload()
+        {
+            byte[] data = { 1, 2, 3, 4, 5, 6 };
+            var encrypted = UID2TokenGenerator.EncryptDataV2(data, SITE_KEY, 12345, DateTime.UtcNow);
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(SITE_KEY));
+            byte[] encryptedBytes = Convert.FromBase64String(encrypted);
+
+            byte[] encryptedBytesMod = new byte[encryptedBytes.Length + 1];
+            Array.Copy(encryptedBytes, encryptedBytesMod, encryptedBytes.Length);
+            var decrypted = client.DecryptData(Convert.ToBase64String(encryptedBytesMod));
+            Assert.Equal(DecryptionStatus.InvalidPayload, decrypted.Status);
+
+            encryptedBytesMod = new byte[encryptedBytes.Length - 2];
+            Array.Copy(encryptedBytes, encryptedBytesMod, encryptedBytes.Length - 2);
+            decrypted = client.DecryptData(Convert.ToBase64String(encryptedBytesMod));
+            Assert.Equal(DecryptionStatus.InvalidPayload, decrypted.Status);
+        }
+
+        [Fact]
+        public void DecryptDataNoDecryptionKey()
+        {
+            byte[] data = { 1, 2, 3, 4, 5, 6 };
+            var encrypted = UID2TokenGenerator.EncryptDataV2(data, SITE_KEY, 12345, DateTime.UtcNow);
+            var client = new UID2Client("ep", "ak", CLIENT_SECRET, IdentityScope.UID2);
+            client.RefreshJson(KeySetToJson(MASTER_KEY));
+            var decrypted = client.DecryptData(encrypted);
+            Assert.Equal(DecryptionStatus.NotAuthorizedForKey, decrypted.Status);
+        }
+
+        private static string KeySetToJson(params Key[] keys)
+        {
+            return @"{""body"": [" + string.Join(",", keys.Select(k => $@"{{""id"": {k.Id},
+                ""site_id"": {k.SiteId},
+                ""created"": {DateTimeUtils.DateTimeToEpochSeconds(k.Created)},
+                ""activates"": {DateTimeUtils.DateTimeToEpochSeconds(k.Activates)},
+                ""expires"": {DateTimeUtils.DateTimeToEpochSeconds(k.Expires)},
+                ""secret"": ""{Convert.ToBase64String(k.Secret)}""
+                }}")) + "]}";
+        }
+
+        private static byte[] MakeTestSecret(byte value)
+        {
+            var ret = new byte[32];
+            Array.Fill(ret, value);
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
- switch querying keys to use v2 APIs
- switch DEP blob encryption to v3 format
- add support for decrypting v3 advertising tokens and DEP blobs
- make site id and identity established timestamp available even if advertising token is expired