### PR TITLE
Bugfix: look up site key site id to encrypt DEP blob from site key used to encrypt advertising token

### DIFF
--- a/UID2.Client.nuspec
+++ b/UID2.Client.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>UID2.Client</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>UID2 C# DSP Client Library</title>
     <authors>TTD</authors>
     <owners>TTD</owners>

--- a/src/UID2.Client/DecryptionResponse.cs
+++ b/src/UID2.Client/DecryptionResponse.cs
@@ -33,18 +33,20 @@ namespace UID2.Client
         private readonly string _uid;
         private readonly DateTime? _established;
         private readonly int? _siteId;
+        private readonly int? _siteKeySiteId;
 
-        public DecryptionResponse(DecryptionStatus status, string uid, DateTime? established, int? siteId)
+        public DecryptionResponse(DecryptionStatus status, string uid, DateTime? established, int? siteId, int? siteKeySiteId)
         {
             _status = status;
             _uid = uid;
             _established = established;
             _siteId = siteId;
+            _siteKeySiteId = siteKeySiteId;
         }
 
         public static DecryptionResponse MakeError(DecryptionStatus status)
         {
-            return new DecryptionResponse(status, null, null, null);
+            return new DecryptionResponse(status, null, null, null, null);
         }
 
         public bool Success => _status == DecryptionStatus.Success;
@@ -52,5 +54,6 @@ namespace UID2.Client
         public string Uid => _uid;
         public DateTime? Established => _established;
         public int? SiteId => _siteId;
+        public int? SiteKeySiteId => _siteKeySiteId;
     }
 }

--- a/src/UID2.Client/UID2Encryption.cs
+++ b/src/UID2.Client/UID2Encryption.cs
@@ -100,11 +100,11 @@ namespace UID2.Client
             var expiry = DateTimeUtils.FromEpochMilliseconds(expiresMilliseconds);
             if (expiry < now)
             {
-                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId);
+                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId, siteKey.SiteId);
             }
             else
             {
-                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId);
+                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId, siteKey.SiteId);
             }
         }
 
@@ -166,11 +166,11 @@ namespace UID2.Client
             var expiry = DateTimeUtils.FromEpochMilliseconds(expiresMilliseconds);
             if (expiry < now)
             {
-                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId);
+                return new DecryptionResponse(DecryptionStatus.ExpiredToken, null, established, siteId, siteKey.SiteId);
             }
             else
             {
-                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId);
+                return new DecryptionResponse(DecryptionStatus.Success, idString, established, siteId, siteKey.SiteId);
             }
         }
 
@@ -186,6 +186,7 @@ namespace UID2.Client
             int siteId = -1;
             if (key == null)
             {
+                int siteKeySiteId = -1;
                 if (keys == null)
                 {
                     return EncryptionDataResponse.MakeError(EncryptionStatus.NotInitialized);
@@ -201,6 +202,7 @@ namespace UID2.Client
                 else if (request.SiteId.HasValue)
                 {
                     siteId = request.SiteId.Value;
+                    siteKeySiteId = siteId;
                 }
                 else
                 {
@@ -213,6 +215,7 @@ namespace UID2.Client
                         }
 
                         siteId = decryptedToken.SiteId.Value;
+                        siteKeySiteId = decryptedToken.SiteKeySiteId.Value;
                     }
                     catch (Exception)
                     {
@@ -220,7 +223,7 @@ namespace UID2.Client
                     }
                 }
 
-                if (!keys.TryGetActiveSiteKey(siteId, now, out key))
+                if (!keys.TryGetActiveSiteKey(siteKeySiteId, now, out key))
                 {
                     return EncryptionDataResponse.MakeError(EncryptionStatus.NotAuthorizedForKey);
                 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
- site id embedded in then token can be different from site id associated with the site key used to encrypt the token