### PR TITLE
Allows  DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow) methods not to do domain name check in case DSPdoesn't want to enable domain name check for CSTG-derived tokens

### DIFF
--- a/src/UID2.Client/IUID2Client.cs
+++ b/src/UID2.Client/IUID2Client.cs
@@ -38,7 +38,18 @@ namespace UID2.Client
         [Obsolete("Please use Decrypt(string token) instead.")]
         DecryptionResponse Decrypt(string token, DateTime utcNow);
         DecryptionResponse Decrypt(string token);
-        DecryptionResponse Decrypt(string token, string expectedDomainName);
+        /// <summary>
+        /// Decrypt advertising token to extract UID2 details and does a domain name check with the provided domainNameFromBidRequest param
+        /// for tokens from Client Side Token Generation 
+        /// </summary>
+        /// <param name="token">The UID2 Token </param>
+        /// <param name="domainNameFromBidRequest">The domain name from bid request which should match the domain name of the publisher (registered with UID2 admin)
+        /// generating this token previously using Client Side Token Generation
+        /// </param>
+        /// <returns>Response showing if decryption is successful and the resulting UID if successful.
+        /// Or it could return error codes/string indicating what went wrong (such as DecryptionStatus.DomainNameCheckFailed)
+        /// </returns>
+        DecryptionResponse Decrypt(string token, string domainNameFromBidRequest);
 
         EncryptionDataResponse Encrypt(string rawUid);
         [Obsolete("Please use Encrypt(string rawUid) instead.")]

--- a/src/UID2.Client/UID2Client.cs
+++ b/src/UID2.Client/UID2Client.cs
@@ -42,12 +42,12 @@ namespace UID2.Client
             return Decrypt(token, utcNow, null, false);
         }
 
-        public DecryptionResponse Decrypt(string token, string expectedDomainName)
+        public DecryptionResponse Decrypt(string token, string domainNameFromBidRequest)
         {
-            return Decrypt(token, DateTime.UtcNow, expectedDomainName, true);
+            return Decrypt(token, DateTime.UtcNow, domainNameFromBidRequest, true);
         }
 
-        public DecryptionResponse Decrypt(string token, DateTime now, string expectedDomainName, bool enableDomainNameCheck = false)
+        private DecryptionResponse Decrypt(string token, DateTime now, string domainNameFromBidRequest, bool enableDomainNameCheck)
         {
             var container = Volatile.Read(ref _container);
             if (container == null)
@@ -62,7 +62,7 @@ namespace UID2.Client
 
             try
             {
-                return UID2Encryption.Decrypt(token, container, now, expectedDomainName, _identityScope, enableDomainNameCheck);
+                return UID2Encryption.Decrypt(token, container, now, domainNameFromBidRequest, _identityScope, enableDomainNameCheck);
             }
             catch (Exception)
             {

--- a/src/UID2.Client/UID2Client.cs
+++ b/src/UID2.Client/UID2Client.cs
@@ -34,20 +34,20 @@ namespace UID2.Client
 
         public DecryptionResponse Decrypt(string token)
         {
-            return Decrypt(token, DateTime.UtcNow, expectedDomainName: null);
+            return Decrypt(token, DateTime.UtcNow, null, false);
         }
 
         public DecryptionResponse Decrypt(string token, DateTime utcNow)
         {
-            return Decrypt(token, utcNow, expectedDomainName: null);
+            return Decrypt(token, utcNow, null, false);
         }
 
         public DecryptionResponse Decrypt(string token, string expectedDomainName)
         {
-            return Decrypt(token, DateTime.UtcNow, expectedDomainName);
+            return Decrypt(token, DateTime.UtcNow, expectedDomainName, true);
         }
 
-        public DecryptionResponse Decrypt(string token, DateTime now, string expectedDomainName)
+        public DecryptionResponse Decrypt(string token, DateTime now, string expectedDomainName, bool enableDomainNameCheck = false)
         {
             var container = Volatile.Read(ref _container);
             if (container == null)
@@ -62,7 +62,7 @@ namespace UID2.Client
 
             try
             {
-                return UID2Encryption.Decrypt(token, container, now, expectedDomainName, _identityScope);
+                return UID2Encryption.Decrypt(token, container, now, expectedDomainName, _identityScope, enableDomainNameCheck);
             }
             catch (Exception)
             {

--- a/src/UID2.Client/UID2Encryption.cs
+++ b/src/UID2.Client/UID2Encryption.cs
@@ -269,8 +269,7 @@ namespace UID2.Client
                 {
                     try
                     {
-                        // Decryption will fail if the token is a CSTG-derived token.
-                        // In that case the caller would have to provide siteId as part of the EncryptionDataRequest.
+                        // if the enableDomainNameCheck param is enabled , the caller would have to provide siteId as part of the EncryptionDataRequest.
                         DecryptionResponse decryptedToken = Decrypt(request.AdvertisingToken, keys, now, domainName: null, identityScope, false);
                         if (!decryptedToken.Success)
                         {

--- a/test/UID2.Client.Test/EncryptionTestsV2.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV2.cs
@@ -74,7 +74,7 @@ namespace UID2.Client.Test
         // if there is domain name associated with sites but we explicitly call 
         // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
         // and we do not want to do domain name check
-        // the Decrypt function would still pass
+        // the Decrypt function would still decrypt successfully
         // in case DSP does not want to enable domain name check
         [Fact]
         public void TokenIsCstgDerivedNoDomainNameTest()

--- a/test/UID2.Client.Test/EncryptionTestsV2.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV2.cs
@@ -44,7 +44,7 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);
@@ -64,11 +64,29 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.False(res.Success);
             Assert.Equal(DecryptionStatus.DomainNameCheckFailed, res.Status);
             Assert.Null(res.Uid);
+        }
+        
+        // if there is domain name associated with sites but we explicitly call 
+        // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
+        // and we do not want to do domain name check
+        // the Decrypt function would still pass
+        // in case DSP does not want to enable domain name check
+        [Fact]
+        public void TokenIsCstgDerivedNoDomainNameTest()
+        {
+            _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
+            var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+            var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
+            var res = _client.Decrypt(advertisingToken);
+            Assert.True(res.IsClientSideGenerated);
+            Assert.True(res.Success);
+            Assert.Equal(DecryptionStatus.Success, res.Status);
+            Assert.Equal(EXAMPLE_UID, res.Uid);
         }
 
         [Theory]
@@ -82,7 +100,7 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(false).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.False(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);

--- a/test/UID2.Client.Test/EncryptionTestsV3.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV3.cs
@@ -73,7 +73,7 @@ namespace UID2.Client.Test
         // if there is domain name associated with sites but we explicitly call 
         // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
         // and we do not want to do domain name check
-        // the Decrypt function would still pass
+        // the Decrypt function would still decrypt successfully
         // in case DSP does not want to enable domain name check
         [Fact]
         public void TokenIsCstgDerivedNoDomainNameTest()

--- a/test/UID2.Client.Test/EncryptionTestsV3.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV3.cs
@@ -43,7 +43,7 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);
@@ -63,11 +63,29 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.False(res.Success);
             Assert.Equal(DecryptionStatus.DomainNameCheckFailed, res.Status);
             Assert.Null(res.Uid);
+        }
+        
+        // if there is domain name associated with sites but we explicitly call 
+        // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
+        // and we do not want to do domain name check
+        // the Decrypt function would still pass
+        // in case DSP does not want to enable domain name check
+        [Fact]
+        public void TokenIsCstgDerivedNoDomainNameTest()
+        {
+            _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
+            var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+            var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
+            var res = _client.Decrypt(advertisingToken);
+            Assert.True(res.IsClientSideGenerated);
+            Assert.True(res.Success);
+            Assert.Equal(DecryptionStatus.Success, res.Status);
+            Assert.Equal(EXAMPLE_UID, res.Uid);
         }
 
         [Theory]
@@ -81,7 +99,7 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(false).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.False(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);

--- a/test/UID2.Client.Test/EncryptionTestsV4.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV4.cs
@@ -184,7 +184,7 @@ namespace UID2.Client.Test
         // if there is domain name associated with sites but we explicitly call 
         // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
         // and we do not want to do domain name check
-        // the Decrypt function would still pass
+        // the Decrypt function would still decrypt successfully
         // in case DSP does not want to enable domain name check
         [Fact]
         public void TokenIsCstgDerivedNoDomainNameTest()

--- a/test/UID2.Client.Test/EncryptionTestsV4.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV4.cs
@@ -154,7 +154,7 @@ namespace UID2.Client.Test
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             string advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
             ValidateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email);
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);
@@ -174,11 +174,29 @@ namespace UID2.Client.Test
             _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
             var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.True(res.IsClientSideGenerated);
             Assert.False(res.Success);
             Assert.Equal(DecryptionStatus.DomainNameCheckFailed, res.Status);
             Assert.Null(res.Uid);
+        }
+        
+        // if there is domain name associated with sites but we explicitly call 
+        // DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow)
+        // and we do not want to do domain name check
+        // the Decrypt function would still pass
+        // in case DSP does not want to enable domain name check
+        [Fact]
+        public void TokenIsCstgDerivedNoDomainNameTest()
+        {
+            _client.RefreshJson(KeySharingResponse(new [] { MASTER_KEY, SITE_KEY }));
+            var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(true).Build();
+            var advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
+            var res = _client.Decrypt(advertisingToken);
+            Assert.True(res.IsClientSideGenerated);
+            Assert.True(res.Success);
+            Assert.Equal(DecryptionStatus.Success, res.Status);
+            Assert.Equal(EXAMPLE_UID, res.Uid);
         }
 
         [Theory]
@@ -193,7 +211,7 @@ namespace UID2.Client.Test
             var privacyBits = PrivacyBitsBuilder.Builder().WithClientSideGenerated(false).Build();
             string advertisingToken = _tokenBuilder.WithPrivacyBits(privacyBits).Build();
             ValidateAdvertisingToken(advertisingToken, IdentityScope.UID2, IdentityType.Email);
-            var res = _client.Decrypt(advertisingToken, NOW, domainName);
+            var res = _client.Decrypt(advertisingToken, domainName);
             Assert.False(res.IsClientSideGenerated);
             Assert.True(res.Success);
             Assert.Equal(DecryptionStatus.Success, res.Status);


### PR DESCRIPTION
Allows  DecryptionResponse Decrypt(string token) or DecryptionResponse Decrypt(string token, DateTime utcNow) methods not to do domain name check in case DSPdoesn't want to enable domain name check for CSTG-derived tokens