### PR TITLE
Use EUID scope for ad token v3 tests

### DIFF
--- a/test/UID2.Client.Test/EncryptionTestsV3.cs
+++ b/test/UID2.Client.Test/EncryptionTestsV3.cs
@@ -9,8 +9,8 @@ namespace UID2.Client.Test
 {
     public class EncryptionTestsV3
     {
-        private readonly UID2Client _client = new("endpoint", "authkey", CLIENT_SECRET, IdentityScope.UID2);
-        private readonly AdvertisingTokenBuilder _tokenBuilder = AdvertisingTokenBuilder.Builder().WithVersion(AdvertisingTokenBuilder.TokenVersion.V3);
+        private readonly UID2Client _client = new("endpoint", "authkey", CLIENT_SECRET, IdentityScope.EUID);
+        private readonly AdvertisingTokenBuilder _tokenBuilder = AdvertisingTokenBuilder.Builder().WithVersion(AdvertisingTokenBuilder.TokenVersion.V3).WithScope(IdentityScope.EUID);
 
         [Theory]
         [InlineData(EXAMPLE_EMAIL_RAW_UID2_V2, nameof(IdentityScope.UID2), IdentityType.Email)]

--- a/test/UID2.Client.Test/builder/AdvertisingTokenBuilder.cs
+++ b/test/UID2.Client.Test/builder/AdvertisingTokenBuilder.cs
@@ -14,7 +14,7 @@ namespace uid2_client.test.builder
         public int SiteId => SITE_ID;
         public int PrivacyBits { get; private set; } = PrivacyBitsBuilder.Builder().WithAllFlagsDisabled().Build();
         public DateTime Expiry { get; private set; } = DateTime.UtcNow.AddHours(1);
-        public IdentityScope Scope => IdentityScope.UID2;
+        public IdentityScope Scope { get; private set; } = IdentityScope.UID2;
 
         internal static AdvertisingTokenBuilder Builder()
         {
@@ -54,6 +54,12 @@ namespace uid2_client.test.builder
         internal AdvertisingTokenBuilder WithExpiry(DateTime expiry)
         {
             Expiry = expiry;
+            return this;
+        }
+
+        internal AdvertisingTokenBuilder WithScope(IdentityScope scope)
+        {
+            Scope = scope;
             return this;
         }
 


### PR DESCRIPTION
Ad token V3 is only used in EUID. By changing the scope of the ad token V3 tests to EUID, we get test coverage for CSTG in EUID.